### PR TITLE
Parametrize `pe` detector name in the descriptor

### DIFF
--- a/startup/80-areadetector.py
+++ b/startup/80-areadetector.py
@@ -128,10 +128,10 @@ def take_dark(cam, light_field, dark_field_name):
 class XPDFileStoreTIFFSquashing(FileStoreTIFFSquashing):
     def describe(self):
         description = super().describe()
-        shape = list(description["pe1c_image"]["shape"])
+        shape = list(description[f"{self.parent.name}_image"]["shape"])
         shape[0] = self.get_frames_per_point()
         shape = tuple(shape)
-        description["pe1c_image"]["shape"] = shape
+        description[f"{self.parent.name}_image"]["shape"] = shape
         return description
 
 


### PR DESCRIPTION
This is a follow-up correction to the earlier fix https://github.com/NSLS-II-PDF/profile_collection/commit/89b338bf698256680f631377680a439acd52667e that I implemented and tested at XPD (see https://github.com/NSLS-II-XPD/profile_collection/commit/75d77203f3e2c8e25ecf10ab2b5a312f81f0249d).