### PR TITLE
🐆 Implement tiled quality-of-service for priority requests

### DIFF
--- a/scripts/pdf_Kafka/dev/kafka_server backup.py
+++ b/scripts/pdf_Kafka/dev/kafka_server backup.py
@@ -16,7 +16,9 @@ bin_ndarray = importlib.import_module("kafka_uti").bin_ndarray
 
 "--------------------------USER INPUTS------------------------------"
 tiled_client = from_profile('pdf')
+tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 sandbox_tiled = from_uri("https://tiled.nsls2.bnl.gov/api/v1/metadata/xpd/sandbox")
+sandbox_tiled.context.http_client.headers['tiled-qos'] = 'acquisition'
 ini_config = '/home/xf28id1/.ipython/profile_collection/scripts/pdf_Kafka/pilatus_kafka_config.ini'
 k_log = kafka_log()
 

--- a/scripts/pdf_Kafka/imgData_2D.py
+++ b/scripts/pdf_Kafka/imgData_2D.py
@@ -4,6 +4,7 @@ import tifffile
 from configparser import ConfigParser
 from tiled.client import from_profile
 tiled_client = from_profile('pdf')
+tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 
 

--- a/scripts/pdf_Kafka/kafka_server.py
+++ b/scripts/pdf_Kafka/kafka_server.py
@@ -17,7 +17,9 @@ bin_ndarray = importlib.import_module("kafka_uti").bin_ndarray
 
 "--------------------------USER INPUTS------------------------------"
 tiled_client = from_profile('pdf')
+tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 sandbox_tiled = from_uri("https://tiled.nsls2.bnl.gov/api/v1/metadata/xpd/sandbox")
+sandbox_tiled.context.http_client.headers['tiled-qos'] = 'acquisition'
 ini_config = '/home/xf28id1/.ipython/profile_collection/scripts/pdf_Kafka/pilatus_kafka_config.ini'
 k_log = kafka_log()
 

--- a/scripts/pdf_Kafka/old_tuner/pdf_kafka_pilatus.py
+++ b/scripts/pdf_Kafka/old_tuner/pdf_kafka_pilatus.py
@@ -18,7 +18,9 @@ bin_ndarray = importlib.import_module("kafka_uti").bin_ndarray
 
 "--------------------------USER INPUTS------------------------------"
 tiled_client = from_profile('pdf')
+tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 sandbox_tiled = from_uri("https://tiled.nsls2.bnl.gov/api/v1/metadata/xpd/sandbox")
+sandbox_tiled.context.http_client.headers['tiled-qos'] = 'acquisition'
 ini_config = '/home/xf28id1/.ipython/profile_collection/scripts/pdf_Kafka/pilatus_kafka_config.ini'
 k_log = kafka_log()
 

--- a/scripts/pdf_Kafka/old_tuner/pilatus_sum.py
+++ b/scripts/pdf_Kafka/old_tuner/pilatus_sum.py
@@ -4,6 +4,7 @@ import tifffile
 from configparser import ConfigParser
 from tiled.client import from_profile
 tiled_client = from_profile('pdf')
+tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 
 

--- a/scripts/zmq/zmq_publisher.py
+++ b/scripts/zmq/zmq_publisher.py
@@ -14,6 +14,7 @@ RE.subscribe(pub)
 '''
 
 tiled_client = from_profile('pdf')
+tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 uid = '004bbfe2-11e6-4658-9ae3-75ed6019eb5d'
 

--- a/startup/00-base.py
+++ b/startup/00-base.py
@@ -50,6 +50,7 @@ ip = get_ipython()
 ip.prompts = ProposalIDPrompt(ip)
 
 tiled_writing_client = from_profile('pdf', api_key=os.getenv("TILED_BLUESKY_WRITING_API_KEY_PDF", ""))
+tiled_writing_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 class TiledInserter:
     name = 'pdf'

--- a/startup/98-CHL_EPICS_function.py
+++ b/startup/98-CHL_EPICS_function.py
@@ -1433,6 +1433,7 @@ def scan_shifter_saxs2(
 def _read_pilatus_int(uid):
     from tiled.client import from_profile
     tiled_client = from_profile('pdf')
+    tiled_client.context.http_client.headers['tiled-qos'] = 'acquisition'
     run = tiled_client[uid]
     img = np.float32(getattr(run, 'primary').read()['pilatus-1_image'].to_numpy()[0][0])
 

--- a/startup_backup_20250917/00-base.py
+++ b/startup_backup_20250917/00-base.py
@@ -33,6 +33,7 @@ ip = get_ipython()
 ip.prompts = ProposalIDPrompt(ip)
 
 tiled_writing_client = from_profile('pdf', api_key=os.getenv("TILED_BLUESKY_WRITING_API_KEY_PDF", ""))
+tiled_writing_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 class TiledInserter:
     name = 'pdf'


### PR DESCRIPTION
Tiled recently added a mechanism to ensure that critical path writing requests made during data acquisition go through, while other Prefect workflows that are not as tightly coupled to operations are put on a scheduled queue such that the Tiled servers will be less likely to become saturated / go down / become unavailable e.g.

_There might be a few redundant calls in this one idk_